### PR TITLE
Added HTTP/2 Support

### DIFF
--- a/cmd/offat/flag.go
+++ b/cmd/offat/flag.go
@@ -36,6 +36,8 @@ type FlagConfig struct {
 	// Report
 	AvoidImmuneFilter *bool
 	OutputFilePath    *string
+
+	HTTP2 *bool
 }
 
 // Custom type for headers

--- a/cmd/offat/main.go
+++ b/cmd/offat/main.go
@@ -106,8 +106,6 @@ func main() {
 		log.Error().Err(err).Msg("failed to set baseUrl")
 	}
 
-	fmt.Println(config.BaseUrl)
-
 	// set struct DocHttpParams
 	if err := parser.Doc.SetDocHttpParams(); err != nil {
 		log.Error().Stack().Err(err).Msg("failed while fetching doc http params")
@@ -122,15 +120,12 @@ func main() {
 		hc = http.NewConfigHttp2(config.RequestsPerSecond, config.SkipTlsVerification, config.Proxy)
 	} else {
 		httpCfg := http.NewConfig(config.RequestsPerSecond, config.SkipTlsVerification, config.Proxy)
-		new_http := http.NewHttp(httpCfg)
-		hc = new_http.Client.FHClient
+		hc = http.NewHttp(httpCfg).Client.FHClient
 	}
 
 	// Test server connectivity
-	// url := *parser.Doc.GetBaseUrl()
-	url := "https://petstore.swagger.io/v2/store/inventory" // Uncomment for testing
+	url := *parser.Doc.GetBaseUrl()
 
-	// resp, err := hc.Client.FHClient.Do(url, fasthttp.MethodGet, nil, nil, nil)
 	resp, err := hc.Do(url, fasthttp.MethodGet, nil, nil, nil)
 	if err != nil {
 		log.Error().Stack().Err(err).Msg("cannot connect to server")

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/invopop/yaml v0.3.1 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/klauspost/compress v1.17.9 // indirect
-	github.com/li-jin-gou/http2curl v0.1.2 // indirect
+	github.com/li-jin-gou/http2curl v0.1.2
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
@@ -36,8 +36,8 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
-	golang.org/x/net v0.29.0 // indirect
+	golang.org/x/net v0.29.0
 	golang.org/x/sys v0.25.0 // indirect
 	golang.org/x/text v0.18.0 // indirect
-	golang.org/x/time v0.6.0 // indirect
+	golang.org/x/time v0.6.0
 )

--- a/pkg/http/http2.go
+++ b/pkg/http/http2.go
@@ -1,0 +1,154 @@
+package http
+
+import (
+	"bytes"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/dmdhrumilmistry/fasthttpclient/client"
+	"github.com/li-jin-gou/http2curl"
+	"github.com/rs/zerolog/log"
+	"golang.org/x/net/http2"
+	"golang.org/x/time/rate"
+)
+
+type ThrottledTransport struct {
+	roundTripperWrap http.RoundTripper
+	ratelimiter      *rate.Limiter
+}
+
+type CustomClient struct {
+	Client *http.Client
+}
+
+func GetResponseHeaders(resp *http.Response) map[string]string {
+	headers := make(map[string]string)
+	for header, value := range resp.Header {
+		headers[header] = value[0]
+	}
+	return headers
+}
+
+func SetRequestBody(body interface{}, req *http.Request) error {
+	if body == nil {
+		return nil
+	}
+
+	bodyBytes, ok := body.([]byte)
+	if !ok {
+		return fmt.Errorf("body only supports []byte type")
+	} else {
+		req.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+	}
+	return nil
+}
+
+func (c *CustomClient) Do(uri string, method string, queryParams any, headers any, reqBody any) (*client.Response, error) {
+	req, err := http.NewRequest(method, uri, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	queryParamsMap, ok := queryParams.(map[string]string)
+	if !ok && queryParams != nil {
+		return nil, fmt.Errorf("queryParams must be a map[string]string")
+	} else {
+		for key, value := range queryParamsMap {
+			req.Header.Add(key, value)
+		}
+	}
+
+	err = SetRequestBody(reqBody, req)
+	if err != nil {
+		return nil, err
+	}
+
+	curlCmd := "error generating curl command"
+	curlCmdObj, err := http2curl.GetCurlCommand(req)
+	if err == nil {
+		curlCmd = curlCmdObj.String()
+	}
+
+	now := time.Now()
+	resp, err := c.Client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	elapsed := time.Since(now)
+
+	// fmt.Println("HTTP Version:", resp.Proto) // To check if HTTP/2 is being used
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	respHeaders := GetResponseHeaders(resp)
+	statusCode := resp.StatusCode
+
+	return &client.Response{StatusCode: statusCode, Body: body, Headers: respHeaders, CurlCommand: curlCmd, TimeElapsed: elapsed}, nil
+}
+
+// RoundTrip method implements the rate limiting logic for HTTP requests
+func (c *ThrottledTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	err := c.ratelimiter.Wait(r.Context()) // This is a blocking call. Honors the rate limit
+	if err != nil {
+		return nil, err
+	}
+	return c.roundTripperWrap.RoundTrip(r)
+}
+
+// NewThrottledTransport wraps the provided transport with a rate limiter
+func NewThrottledTransport(limitPeriod time.Duration, requestCount int, transportWrap http.RoundTripper) http.RoundTripper {
+	return &ThrottledTransport{
+		roundTripperWrap: transportWrap,
+		ratelimiter:      rate.NewLimiter(rate.Every(limitPeriod), requestCount),
+	}
+}
+
+func NewConfigHttp2(requestsPerSecond *int, skipTlsVerification *bool, proxy *string) *CustomClient {
+	tlsConfig := &tls.Config{
+		InsecureSkipVerify: *skipTlsVerification,
+		MinVersion:         tls.VersionTLS12,
+		CipherSuites: []uint16{
+			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+			tls.TLS_AES_128_GCM_SHA256,       // TLS 1.3
+			tls.TLS_AES_256_GCM_SHA384,       // TLS 1.3
+			tls.TLS_CHACHA20_POLY1305_SHA256, // TLS 1.3
+		},
+		PreferServerCipherSuites: true,
+	}
+
+	var transport *http.Transport
+	if *proxy != "" {
+		proxy_url, _ := url.Parse(*proxy)
+		transport = &http.Transport{
+			TLSClientConfig: tlsConfig,
+			Proxy:           http.ProxyURL(proxy_url),
+		}
+	} else {
+		transport = &http.Transport{
+			TLSClientConfig: tlsConfig,
+		}
+	}
+
+	err := http2.ConfigureTransport(transport)
+	if err != nil {
+		log.Error().Msgf("failed to configure transport: %v", err)
+	}
+
+	rateLimitedTransport := NewThrottledTransport(1*time.Second, *requestsPerSecond, transport)
+
+	client := http.Client{
+		Transport: rateLimitedTransport,
+	}
+
+	return &CustomClient{
+		Client: &client,
+	}
+}

--- a/pkg/http/http2.go
+++ b/pkg/http/http2.go
@@ -80,8 +80,6 @@ func (c *CustomClient) Do(uri string, method string, queryParams any, headers an
 	}
 	elapsed := time.Since(now)
 
-	// fmt.Println("HTTP Version:", resp.Proto) // To check if HTTP/2 is being used
-
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err

--- a/pkg/http/http2.go
+++ b/pkg/http/http2.go
@@ -22,7 +22,9 @@ type ThrottledTransport struct {
 }
 
 type CustomClient struct {
-	Client *http.Client
+	Requests  []*client.Request
+	Responses []*client.ConcurrentResponse
+	Client    *http.Client
 }
 
 func GetResponseHeaders(resp *http.Response) map[string]string {

--- a/pkg/http/http2_test.go
+++ b/pkg/http/http2_test.go
@@ -1,0 +1,33 @@
+package http_test
+
+import (
+	"testing"
+
+	"github.com/owasp-offat/offat/pkg/http"
+
+	c "github.com/dmdhrumilmistry/fasthttpclient/client"
+	"github.com/valyala/fasthttp"
+)
+
+func TestHttp2Client(t *testing.T) {
+	// http2 client
+	requestsPerSecond := 10
+	skipTlsVerification := false
+	proxy := ""
+	hc := http.NewConfigHttp2(&requestsPerSecond, &skipTlsVerification, &proxy)
+
+	url := "https://example.com"
+	hc.Requests = append(hc.Requests, c.NewRequest(url, fasthttp.MethodGet, nil, nil, nil))
+	hc.Requests = append(hc.Requests, c.NewRequest(url, fasthttp.MethodGet, nil, nil, nil))
+
+	t.Run("Concurrent Requests Test", func(t *testing.T) {
+		hc.Responses = c.MakeConcurrentRequests(hc.Requests, hc)
+
+		for _, connResp := range hc.Responses {
+			if connResp.Error != nil {
+				t.Fatalf("failed to make concurrent request: %v\n", connResp.Error)
+			}
+		}
+	})
+
+}

--- a/pkg/http/http_test.go
+++ b/pkg/http/http_test.go
@@ -33,3 +33,25 @@ func TestHttpClient(t *testing.T) {
 	})
 
 }
+func TestHttp2Client(t *testing.T) {
+	// http2 client
+	requestsPerSecond := 10
+	skipTlsVerification := false
+	proxy := ""
+	hc := http.NewConfigHttp2(&requestsPerSecond, &skipTlsVerification, &proxy)
+
+	url := "https://example.com"
+	hc.Requests = append(hc.Requests, c.NewRequest(url, fasthttp.MethodGet, nil, nil, nil))
+	hc.Requests = append(hc.Requests, c.NewRequest(url, fasthttp.MethodGet, nil, nil, nil))
+
+	t.Run("Concurrent Requests Test", func(t *testing.T) {
+		hc.Responses = c.MakeConcurrentRequests(hc.Requests, hc)
+
+		for _, connResp := range hc.Responses {
+			if connResp.Error != nil {
+				t.Fatalf("failed to make concurrent request: %v\n", connResp.Error)
+			}
+		}
+	})
+
+}

--- a/pkg/http/http_test.go
+++ b/pkg/http/http_test.go
@@ -33,25 +33,3 @@ func TestHttpClient(t *testing.T) {
 	})
 
 }
-func TestHttp2Client(t *testing.T) {
-	// http2 client
-	requestsPerSecond := 10
-	skipTlsVerification := false
-	proxy := ""
-	hc := http.NewConfigHttp2(&requestsPerSecond, &skipTlsVerification, &proxy)
-
-	url := "https://example.com"
-	hc.Requests = append(hc.Requests, c.NewRequest(url, fasthttp.MethodGet, nil, nil, nil))
-	hc.Requests = append(hc.Requests, c.NewRequest(url, fasthttp.MethodGet, nil, nil, nil))
-
-	t.Run("Concurrent Requests Test", func(t *testing.T) {
-		hc.Responses = c.MakeConcurrentRequests(hc.Requests, hc)
-
-		for _, connResp := range hc.Responses {
-			if connResp.Error != nil {
-				t.Fatalf("failed to make concurrent request: %v\n", connResp.Error)
-			}
-		}
-	})
-
-}

--- a/pkg/trunner/runner.go
+++ b/pkg/trunner/runner.go
@@ -7,14 +7,13 @@ import (
 
 	c "github.com/dmdhrumilmistry/fasthttpclient/client"
 	"github.com/k0kubun/go-ansi"
-	"github.com/owasp-offat/offat/pkg/http"
 	"github.com/owasp-offat/offat/pkg/tgen"
 	"github.com/schollz/progressbar/v3"
 	"golang.org/x/term"
 )
 
 // Runs API Tests
-func RunApiTests(t *tgen.TGenHandler, hc *http.Http, client c.ClientInterface, apiTests []*tgen.ApiTest) {
+func RunApiTests(t *tgen.TGenHandler, client c.ClientInterface, apiTests []*tgen.ApiTest) {
 	var wg sync.WaitGroup
 
 	// Get the terminal size


### PR DESCRIPTION
I made slight changes in your code in order to implement HTTP/2, please let me know if these are no problem:
- Changed `hc` to `c.ClientInterface`
- Removed `hc` argument in function `trunner.RunApiTests` 

Here is a screenshot of the test I ran to check the request was HTTP/2
![Screenshot (3)](https://github.com/user-attachments/assets/be76ba7d-4ae9-4f0e-9de7-fef324aec90e)

Please let me know if any changes are required
#2 